### PR TITLE
Create local frontend make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,3 +38,7 @@ python/centurymetadata/constants.py: templates/constants.py.src vars Makefile
 upload: web/index.html python/centurymetadata/server/server.py
 	rsync -av web/ ozlabs.org:/home/rusty/www/centurymetadata.org/htdocs/
 	rsync python/centurymetadata/server/server.py ozlabs.org:www/centurymetadata.org/cgi/
+
+run-local: 
+	@echo "Starting local server..."
+	@python3 -m http.server 8000 --directory web/


### PR DESCRIPTION
This is a simple makefile command that starts up the frontend on `localhost:8000`

I'm still figuring out the file structure to get the api server setup locally